### PR TITLE
Fix passing parameters to a controller method with default values for pa...

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -1209,7 +1209,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
             return $this->callLumenController($instance, $method, $routeInfo);
         } else {
             return $this->callControllerCallable(
-                [$instance, $method], array_values($routeInfo[2])
+                [$instance, $method], $routeInfo[2]
             );
         }
     }


### PR DESCRIPTION
For a route that looks like this:

  $app->get('/test/{param1}', 'TestController@test');

and a TestController method with a default parameter:

  public function test($param1 = 'default') {

visiting the URL "/test/param1Value" will cause Lumen to call the
method with the following parameters:

  TestController->test('default', 'param1Value');

The value in the URL will not replace $param1 default value, even
though the name in the route parameter is the same: {param1}.

The reason for that is that when this method is called:

  protected function addDependencyForCallParameter(ReflectionParameter $parameter, array &$parameters, &$dependencies)

the $parameters array contains only numeric keys. So this condition
in addDependencyForCallParameter() will never match:

if (array_key_exists($parameter->name, $parameters))
{
    $dependencies[] = $parameters[$parameter->name];

```
unset($parameters[$parameter->name]);
```

}

Removing array_values() call on the $parameters array in the callControllerAction() method seems to fix this issue.
